### PR TITLE
renderer: fix lambdas in two partials with same subs names bug

### DIFF
--- a/lib/template.js
+++ b/lib/template.js
@@ -71,15 +71,8 @@ var Hogan = {};
       this.partials[symbol].base = template;
 
       if (partial.subs) {
-        // Make sure we consider parent template now
         if (!partials.stackText) partials.stackText = {};
-        for (key in partial.subs) {
-          if (!partials.stackText[key]) {
-            partials.stackText[key] = (this.activeSub !== undefined && partials.stackText[this.activeSub]) ? partials.stackText[this.activeSub] : this.text;
-          }
-        }
-        template = createSpecializedPartial(template, partial.subs, partial.partials,
-          this.stackSubs, this.stackPartials, partials.stackText);
+        template = createSpecializedPartial(this, template, partial.subs, partial.partials, partials.stackText);
       }
       this.partials[symbol].instance = template;
 
@@ -283,39 +276,47 @@ var Hogan = {};
     return val;
   }
 
-  function objectAssign(to, source) {
-    for (var key in source) to[key] = source[key];
-    return to;
-  }
-
-  function createSpecializedPartial(instance, subs, partials, stackSubs, stackPartials, stackText) {
-    function PartialTemplate() {};
+  function createSpecializedPartial(parentTpl, instance, subs, partials, stackText) {
+    function PartialTemplate() {}
     PartialTemplate.prototype = instance;
-    function Substitutions() {};
+
+    function Substitutions() {}
     Substitutions.prototype = instance.subs;
+
+    function StackSubstitutions() {}
+    StackSubstitutions.prototype = parentTpl.stackSubs || {};
+
+    function StackPartials() {}
+    StackPartials.prototype = parentTpl.stackPartials || {};
+
+    function StackText() {}
+    StackText.prototype = stackText || {};
+
     var key;
     var partial = new PartialTemplate();
     partial.subs = new Substitutions();
-    partial.subsText = {};  //hehe. substext.
+    partial.subsText = new StackText();
     partial.buf = '';
 
-    stackSubs = stackSubs || {};
-    partial.stackSubs = objectAssign({}, stackSubs);
-    partial.subsText = stackText;
+    var stackSubs = new StackSubstitutions();
+    partial.stackSubs = stackSubs;
     for (key in subs) {
-      if (!partial.stackSubs[key]) partial.stackSubs[key] = subs[key];
+      if (!stackSubs[key]) {
+        stackSubs[key] = subs[key];
+        stackText[key] = (parentTpl.activeSub && stackText[parentTpl.activeSub]) ? stackText[parentTpl.activeSub] : parentTpl.text;
+      }
     }
-    for (key in partial.stackSubs) {
-      partial.subs[key] = partial.stackSubs[key];
+    for (key in stackSubs) {
+      partial.subs[key] = stackSubs[key];
     }
 
-    stackPartials = stackPartials || {};
-    partial.stackPartials = objectAssign({}, stackPartials);
+    var stackPartials = new StackPartials();
+    partial.stackPartials = stackPartials;
     for (key in partials) {
-      if (!partial.stackPartials[key]) partial.stackPartials[key] = partials[key];
+      if (!stackPartials[key]) stackPartials[key] = partials[key];
     }
-    for (key in partial.stackPartials) {
-      partial.partials[key] = partial.stackPartials[key];
+    for (key in stackPartials) {
+      partial.partials[key] = stackPartials[key];
     }
 
     return partial;

--- a/test/index.js
+++ b/test/index.js
@@ -961,6 +961,26 @@ test('Lambdas in deep partials with the same name', function() {
   );
 });
 
+test('Lambdas in two partials with same subs names work', function() {
+  is(
+    Hogan
+    .compile('{{>a}}' +
+             '{{<b}} {{$s}}{{#l}}z{{/l}}{{/s}} {{/b}}')
+    .render({
+      l() {
+        return function(text) {
+          return text.toUpperCase();
+        }
+      }
+    }, {
+      a: Hogan.compile('{{<b}} {{$s}}a{{/s}} {{/b}}'),
+      b: Hogan.compile('{{$s}}{{/s}}')
+    }),
+    'aZ',
+    'lambda must be called with the correct text'
+  );
+});
+
 test("Cache contains old partials instances", function() {
   var tests = [{
     template: "{{<parent}}{{$a}}c{{/a}}{{/parent}}",


### PR DESCRIPTION
Note: also switching from objectAssign to prototypal inheritance, as other objects.